### PR TITLE
Fix: Close mobile menu when a navigation item is clicked

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -111,6 +111,7 @@ const Header: React.FC = () => {
                     key={item.name}
                     href={item.url}
                     className="-mx-3 block rounded-lg py-2 px-3 text-base font-semibold leading-7 text-gray-900 dark:text-gray-50 hover:bg-gray-400/10"
+                    onClick={() => setMobileMenuOpen(false)}
                   >
                     <span className="text-bluebell">
                       {formatIndex(index + 1)}.{' '}


### PR DESCRIPTION
This PR fixes the issue #1 where the mobile menu remains open after clicking a navigation item. Now, when a user clicks on a menu item, the mobile menu will automatically close 

> [!NOTE]   
>I haven't tested this fix, but logically, I think it should work 

